### PR TITLE
Add make_response function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ HTMX Response
 
 You might be interested on adding
 `htmx response headers <https://htmx.org/reference/#response_headers>`_ to your response.
-Use :code:`htmx_flask.make_response` for that. For example, instead of:
+Use :code:`flask_htmx.make_response` for that. For example, instead of:
 
 .. code-block:: python
 
@@ -133,7 +133,7 @@ You can do:
 
 .. code-block:: python
 
-    from htmx_flask import make_response
+    from flask_htmx import make_response
     from my_app import app
 
     @app.route("/hola-mundo")

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,9 @@ Or perhaps you use Poetry.
 
     poetry add flask-htmx
 
+HTMX Request
+------------
+
 You can register the HTMX object by passing the Flask
 :code:`app` object via the constructor.
 
@@ -104,10 +107,49 @@ the current URL of the browser of a HTMX request.
 Other HTMX request headers are also available.
 See https://htmx.org/reference/#request_headers.
 
-Continue to the next section of the docs,
-`The HTMX Class <https://flask-htmx.readthedocs.io/en/latest/flask_htmx.htmx.html>`_.
+HTMX Response
+-------------
+
+You might be interested on adding
+`htmx response headers <https://htmx.org/reference/#response_headers>`_ to your response.
+Use :code:`htmx_flask.make_response` for that. For example, instead of:
+
+.. code-block:: python
+
+    import json
+    from flask import make_response
+    from my_app import app
+
+    @app.route("/hola-mundo")
+    def hola_mundo():
+        body = "Hola Mundo!"
+        response = make_response(body)
+        response.headers["HX-Push-URL"] = "false"
+        trigger_string = json.dumps({"event1":"A message", "event2":"Another message"})
+        response.headers["HX-Trigger"] = trigger_string
+        return response
+
+You can do:
+
+.. code-block:: python
+
+    from htmx_flask import make_response
+    from my_app import app
+
+    @app.route("/hola-mundo")
+    def hola_mundo():
+        body = "Hola Mundo!"
+        return make_response(
+            body,
+            push_url=False,
+            trigger={"event1": "A message", "event2": "Another message"},
+        )
 
 .. quickstart-endblock
+
+Documentation
+=============
+Visit the `full documentation <https://flask-htmx.readthedocs.io>`_.
 
 Development
 ===========

--- a/docs/flask_htmx.responses.rst
+++ b/docs/flask_htmx.responses.rst
@@ -1,0 +1,4 @@
+HTMX Enhanced Responses
+=======================
+
+.. autofunction:: flask_htmx.responses.make_response

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,3 +16,4 @@ functionality for working with `HTMX <https://htmx.org/>`_.
 
    quickstart
    flask_htmx.htmx
+   flask_htmx.responses

--- a/flask_htmx/__init__.py
+++ b/flask_htmx/__init__.py
@@ -1,1 +1,2 @@
 from .htmx import HTMX
+from .responses import make_response

--- a/flask_htmx/constants.py
+++ b/flask_htmx/constants.py
@@ -1,0 +1,18 @@
+#: True and False values for the HX-* request and response headers
+HX_TRUE = "true"
+HX_FALSE = "false"
+
+#: Values allowed for the HX-Reswap response header
+RESWAPS = [
+    "innerHTML",
+    "outerHTML",
+    "beforebegin" "afterbegin",
+    "beforeend",
+    "afterend",
+    "delete",
+    "none",
+]
+
+#: If you want to stop polling from a server response you can respond with the HTTP
+#: response code 286 and the element will cancel the polling.
+HTMX_STOP_POLLING = 286

--- a/flask_htmx/responses.py
+++ b/flask_htmx/responses.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
+import json
+import typing
+
 from flask import Response
+from flask import make_response as flask_make_response
 
-
-#: If you want to stop polling from a server response you can respond with the HTTP response code 286 and
-#: the element will cancel the polling.
-HTMX_STOP_POLLING = 286
+from flask_htmx.constants import HX_FALSE, HX_TRUE, RESWAPS, HTMX_STOP_POLLING
 
 
 class HTMXResponseClientRedirect(Response):
@@ -32,3 +35,86 @@ class HTMXResponseStopPolling(Response):
             mimetype=mimetype,
             direct_passthrough=direct_passthrough,
         )
+
+
+def _stringify(val):
+    return val if isinstance(val, str) else json.dumps(val)
+
+
+def make_response(
+    *args: typing.Any,
+    location: str | dict | None = None,
+    push_url: str | False | None = None,
+    redirect: str | None = None,
+    refresh: bool = False,
+    replace_url: str | False | None = None,
+    reswap: str | None = None,
+    retarget: str | None = None,
+    trigger: str | dict | None = None,
+    trigger_after_settle: str | dict | None = None,
+    trigger_after_swap: str | dict | None = None,
+) -> Response:
+    """
+    This function can be used as a replacement from :code:`flask.make_response` to
+    easily add htmx response headers to the request.
+
+    See https://htmx.org/reference/#response_headers for more details about the headers.
+
+    :param args: Arguments you would normally use with :code:`flask.make_response`.
+    :param location: Allows you to do a client-side redirect that does not do a full
+        page reload. Accepts a string or a dict (:code:`HX-Location`).
+    :param push_url: Pushes a new url into the history stack. Accepts a string—the URL
+        to be pushed into the location bar—or :py:obj:`False`—prevents the browser’s
+        history from being updated—(:code:`HX-Push-URL`).
+    :param redirect: Can be used to do a client-side redirect to a new location
+        (:code:`HX-Redirect`).
+    :param refresh: If set to :py:obj:`True` the client side will do a full refresh of
+        the page (:code:`HX-Refresh`).
+    :param replace_url: Replaces the current URL in the location bar. Accepts a
+        string—the URL to replace the current URL in the location bar—or
+        :py:obj:False:—prevents the browser’s current URL from being
+        updated—(:code:`HX-Replace-URL`).
+    :param reswap: Allows you to specify how the response will be swapped. Possible
+        values: "innerHTML", "outerHTML", "beforebegin" "afterbegin", "beforeend",
+        "afterend", "delete", "none". Notice :py:obj:`None` means to not send the
+        header, which is different from "none" (:code:`HX-Reswap`).
+    :param retarget: A CSS selector that updates the target of the content update to a
+        different element on the page (:code:`HX-Retarget`).
+    :param trigger: Allows you to trigger client side events. Accepts a string or a dict
+        (:code:`HX-Trigger`).
+    :param trigger_after_settle: Allows you to trigger client side events. Accepts a
+        string or a dict (:code:`HT-Trigger-After-Settle`).
+    :param trigger_after_swap: Allows you to trigger client side events. Accepts a
+        string or a dict (:code:`HT-Trigger-After-Swap`).
+    :return: A Flask Response with htmx headers.
+    """
+    if reswap and reswap not in RESWAPS:
+        raise ValueError(
+            f"Invalid reswap value. Must be one of {RESWAPS} (or None to ignore)."
+        )
+    resp = flask_make_response(*args)
+    if location:
+        resp.headers["HX-Location"] = _stringify(location)
+    if push_url:
+        resp.headers["HX-Push-Url"] = push_url
+    elif push_url is False:
+        resp.headers["HX-Push-Url"] = HX_FALSE
+    if redirect:
+        resp.headers["HX-Redirect"] = redirect
+    if refresh:
+        resp.headers["HX-Refresh"] = HX_TRUE
+    if replace_url:
+        resp.headers["HX-Replace-Url"] = replace_url
+    elif replace_url is False:
+        resp.headers["HX-Replace-Url"] = HX_FALSE
+    if reswap:
+        resp.headers["HX-Reswap"] = reswap
+    if retarget:
+        resp.headers["HX-Retarget"] = retarget
+    if trigger:
+        resp.headers["HX-Trigger"] = _stringify(trigger)
+    if trigger_after_settle:
+        resp.headers["HX-Trigger-After-Settle"] = _stringify(trigger_after_settle)
+    if trigger_after_swap:
+        resp.headers["HX-Trigger-After-Swap"] = _stringify(trigger_after_swap)
+    return resp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,9 @@ from flask_htmx import HTMX
 from flask_htmx.responses import HTMXResponseClientRedirect, HTMXResponseStopPolling
 
 
-@pytest.fixture(scope="function")
-def client():
+
+@pytest.fixture(scope="session")
+def flask_app():
     app = Flask(__name__)
     app.config["TESTING"] = True
     htmx = HTMX(app)
@@ -51,5 +52,9 @@ def client():
     def hx_trigger_stop_polling():
         return HTMXResponseStopPolling()
 
-    with app.test_client() as client:
+    yield app
+
+@pytest.fixture(scope="function")
+def client(flask_app):
+    with flask_app.test_client() as client:
         yield client

--- a/tests/test_htmx_responses.py
+++ b/tests/test_htmx_responses.py
@@ -1,4 +1,7 @@
+import pytest
 from flask.testing import FlaskClient
+
+from flask_htmx.responses import make_response
 
 
 def test_htmx_response_client_redirect(client: FlaskClient):
@@ -10,3 +13,99 @@ def test_htmx_response_client_redirect(client: FlaskClient):
 def test_htmx_response_stop_polling(client: FlaskClient):
     rv = client.get("/hx-trigger-stop-polling")
     assert rv.status_code == 286
+
+@pytest.mark.parametrize(
+    "body, data",
+    [
+        (
+            {},
+            {
+                "HX-Location": (None, None),
+                "HX-Push-Url": (None, None),
+                "HX-Redirect": (None, None),
+                "HX-Refresh": (None, None),
+                "HX-Replace-Url": (None, None),
+                "HX-Reswap": (None, None),
+                "HX-Retarget": (None, None),
+                "HX-Trigger": (None, None),
+                "HX-Trigger-After-Settle": (None, None),
+                "HX-Trigger-After-Swap": (None, None),
+            },
+        ),
+        (
+            {"foo": "bar"},
+            {
+                "HX-Location": ("/test", "/test"),
+                "HX-Push-Url": ("http://google.com", "http://google.com"),
+                "HX-Redirect": ("/baz", "/baz"),
+                "HX-Refresh": (None, None),
+                "HX-Replace-Url": ("http://yahoo.com", "http://yahoo.com"),
+                "HX-Reswap": ("outerHTML", "outerHTML"),
+                "HX-Retarget": ("#idname", "#idname"),
+                "HX-Trigger": ("event", "event"),
+                "HX-Trigger-After-Settle": ("event2", "event2"),
+                "HX-Trigger-After-Swap": ("event3", "event3"),
+            },
+        ),
+        (
+            "foo",
+            {
+                "HX-Location": (
+                    {"path": "/test2", "target": "#testdiv"},
+                    '{"path": "/test2", "target": "#testdiv"}',
+                ),
+                "HX-Push-Url": (False, "false"),
+                "HX-Redirect": (None, None),
+                "HX-Refresh": (True, "true"),
+                "HX-Replace-Url": (False, "false"),
+                "HX-Reswap": ("none", "none"),
+                "HX-Retarget": (None, None),
+                "HX-Trigger": (
+                    {"showMessage": "Here Is A Message"},
+                    '{"showMessage": "Here Is A Message"}',
+                ),
+                "HX-Trigger-After-Settle": (
+                    {
+                        "showMessage": {
+                            "level": "info",
+                            "message": "Here Is A Message",
+                        }
+                    },
+                    '{"showMessage": {"level": "info", "message": "Here Is A Message"}}',  # noqa
+                ),
+                "HX-Trigger-After-Swap": (
+                    {"event1": "A message", "event2": "Another message"},
+                    '{"event1": "A message", "event2": "Another message"}',
+                ),
+            },
+        ),
+    ],
+)
+def test_make_response(flask_app, body, data):
+    mapping = {
+        "location": "HX-Location",
+        "push_url": "HX-Push-Url",
+        "redirect": "HX-Redirect",
+        "refresh": "HX-Refresh",
+        "replace_url": "HX-Replace-Url",
+        "reswap": "HX-Reswap",
+        "retarget": "HX-Retarget",
+        "trigger": "HX-Trigger",
+        "trigger_after_settle": "HX-Trigger-After-Settle",
+        "trigger_after_swap": "HX-Trigger-After-Swap",
+    }
+    kwargs = {key: data[header][0] for key, header in mapping.items()}
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    with flask_app.app_context():
+        resp = make_response(body, **kwargs)
+    for header, value in data.items():
+        if value[0] is None:
+            assert header not in resp.headers
+        else:
+            assert value[1] == resp.headers[header]
+
+
+def test_make_response_invalid_reswap(flask_app):
+    with flask_app.app_context():
+        with pytest.raises(ValueError):
+            make_response("body", reswap="invalid_reswap")


### PR DESCRIPTION
This PR adds a new function, `make_response`, that works like Flask's `make_response` but with extra arguments to help setting htmx headers in a pythonic way.

It includes updates tests for 100% coverage, and README.rst and Sphinx documentation.