### PR TITLE
Fix HX-Boosted header

### DIFF
--- a/flask_htmx/htmx.py
+++ b/flask_htmx/htmx.py
@@ -32,7 +32,7 @@ class HTMX:
 
         Based on the :code:`HX-Boosted` header.
         """
-        return request.headers.get("HX-Boost") == "true"
+        return request.headers.get("HX-Boosted") == "true"
 
     @property
     def current_url(self) -> Optional[str]:

--- a/tests/test_htmx_request_headers.py
+++ b/tests/test_htmx_request_headers.py
@@ -2,7 +2,7 @@ from flask.testing import FlaskClient
 
 
 def test_hx_boost_true(client: FlaskClient):
-    headers = {"HX-Boost": "true"}
+    headers = {"HX-Boosted": "true"}
     rv = client.get("/hx-boost", headers=headers)
     assert rv.data.decode("utf-8") == "True"
 


### PR DESCRIPTION
According to the [documentation ](https://htmx.org/reference/#request_headers), the header key is `HX-Boosted`, and not `HX-Boost`. The attribute on the HTML element is `hx-boost`, though.